### PR TITLE
Add UCI option "EngineHome" if basic.ini was not found

### DIFF
--- a/sources/src/rodent.h
+++ b/sources/src/rodent.h
@@ -1117,6 +1117,7 @@ extern bool SkipBeginningOfLog;
 
 void FullPathEndSlash(std::wstring &pathWStr);
 void SetRodentHomeDir();
+bool DirOrFileExists(const char* path);
 void CreateRodentHome(const char *RodentDir);
 void ChangePersonalitySet(int persSetNo);
 

--- a/sources/src/uci_options.cpp
+++ b/sources/src/uci_options.cpp
@@ -70,6 +70,9 @@ void PrintUciOptions() {
     PrintUciOptionInfo("Build Time", ss.str().c_str());
 #endif
 
+    if (!DirOrFileExists(WStr2Str(RodentHomeDirWStr + L"personalities/basic.ini").c_str()))
+        printfUciOut(std::string("option name EngineHome type string default " + WStr2Str(RodentHomeDirWStr) + "\n").c_str());
+
 	printfUciOut("option name Clear Hash type button\n");
     printfUciOut("option name Hash type spin default 16 min 1 max %d\n", max_tt_size_mb);
 
@@ -500,6 +503,9 @@ void ParseSetoption(const char *ptr) {
             }
         if (Glob.personalityB == "")
             ReadPersonality(Glob.personalityW.c_str());
+    } else if (strcmp(name, "enginehome") == 0) {
+        RodentHomeDirWStr = CStr2WStr(value);
+        ReadPersonality("basic.ini");
     }
 }
 


### PR DESCRIPTION
Adds the possibility to set the engine home directory via an UCI option.
Useful on Android when the personalities and books directories are
located in one of the apps private files directory, even if the engine binary itself is located somewhere else (e.g. as an OEX engine). Also file permissions are not needed if the additional files needed by the engine are not in the default directory /sdcard/Rodent4 
